### PR TITLE
set document title based on vars.id (serial number)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ node_modules
 .esm-cache
 dist
 .idea
+wetty_term_key

--- a/README.Duke.md
+++ b/README.Duke.md
@@ -1,0 +1,28 @@
+# WeTTY - Duke customization
+
+## Finding Duke code
+Please surround Duke custom code with the following comments for findability:
+
+    Begin Duke customization
+    End Duke customization
+
+## Running locally on development machine
+You'll need to have Docker installed and running.  And AWS credentials setup on your machine.
+1) Copy down `s3://de-iot-hmb-wetty-certs/wetty_term_key` to root of the project workspace
+2) Run 
+
+       $(aws ecr get-login --region us-east-1 --no-include-email --registry-ids 886993334988)
+       
+3) Build, run, and follow logs:
+
+
+       docker container kill $(docker ps -q --filter ancestor=dev/wetty) && \
+       docker build -t dev/wetty . && \
+       wetty_container=$(docker run -d -p 3000:3000 dev/wetty) && \
+       echo $wetty_container && \
+       docker exec -t $wetty_container service ssh start && \
+       docker logs -f $wetty_container
+
+4) URL should look something like this:
+
+    http://localhost:3000/wetty/ssh/term?pass=term&vars={%22id%22:%22P20101234%22,%22ipAddress%22:%2222.23.17.34%22,%22hub%22:%22gw-default-prov%22}

--- a/src/server/socketServer/html.ts
+++ b/src/server/socketServer/html.ts
@@ -32,6 +32,13 @@ export default (base: string, title: string) => (
     </div>
     <div id="terminal"></div>
     <script src="${resourcePath}public/index.js"></script>
+
+    // Begin Duke customization
+    <script>
+        document.title = JSON.parse(new URLSearchParams(window.location.search).get('vars')).id || '${title}';
+    </script>
+    // End Duke customization
+
   </body>
 </html>`);
 };


### PR DESCRIPTION
- will set document title (so the Chrome tab shows serial number for WeTTy instances) if vars.id is set in the query parameter
- added some documentation on running locally